### PR TITLE
Enable permission check, and status check in onboarding script

### DIFF
--- a/Onboarding/Connector/Scripts/CreateImpactReportingConnector.ps1
+++ b/Onboarding/Connector/Scripts/CreateImpactReportingConnector.ps1
@@ -52,10 +52,10 @@ function Log {
 
   $date = Get-Date
   if (-not $ForegroundColor) {
-    Write-Host "$date - $Message" 2>&1
+    Write-Host "$date - $Message"
   }
   else {
-    Write-Host "$date - $Message" -ForegroundColor $ForegroundColor 2>&1
+    Write-Host "$date - $Message" -ForegroundColor $ForegroundColor
   }
 }
 
@@ -159,7 +159,7 @@ function Add-PermissionsForAlertReading {
 
   $RoleId = (Get-AzRoleDefinition -Name $ALERTS_READER_ROLE_NAME).id
   if (-not $RoleId) {
-      Log "Creating custom role for alert reading."
+      Log "Creating custom role: '$ALERTS_READER_ROLE_NAME' for the Impact Reporting Connector resource to read alerts in this subscription"
       $CustomRoleJsonFilePath = "/tmp/azure-alerts-reader-role-definition.json"
       CreateCustomRoleJson $SubscriptionId $ALERTS_READER_ROLE_NAME | Out-File $CustomRoleJsonFilePath
       $RoleId = (New-AzRoleDefinition -InputFile $CustomRoleJsonFilePath).id
@@ -212,7 +212,7 @@ function CreateConnector {
       $ResponseContent = $Response.Content
       $StatusCode = $Response.StatusCode
       if ( $StatusCode -eq 409 ) {
-          Log "A connector is already deployed in this subscription. A new connector will not be deployed." -ForegroundColor yellow
+          Log "An Azure Monitor connector already exists in this subscription. A new connector creation is not required." -ForegroundColor yellow
           break;
       }
       $ResponseBody = $ResponseContent | ConvertFrom-Json
@@ -288,13 +288,13 @@ function CheckRoleAssignmentForSettingUpPermissions {
   if (-not $roleId) {
       Write-Host "Custom role: $ALERTS_READER_ROLE_NAME for alerts reading does not exist. Checking for built-in role: User Access Administrator role assignment as that is required for custom role creation"
       if (-not (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "User Access Administrator")) {
-          Write-Host "You are not a 'User Access Administrator' on the subscription: $SubscriptionId. Please get the role assigned to proceed"
+          Write-Host "You are not a 'User Access Administrator' on the subscription: $SubscriptionId.  Please reach out to someone in your organization who can assign one of these roles to you. Once you have them, run this script again."
           exit 1
       }
   }
 
   if (-not (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "Role Based Access Administrator") -and -not (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "User Access Administrator")) {
-      Write-Host "You are neither a 'Role Based Access Administrator' nor a 'User Access Administrator' on the subscription: $SubscriptionId which is required to assign alert reading permission to the connectors app. Please get the role assigned to proceed"
+      Write-Host "You are neither a 'Role Based Access Administrator' nor a 'User Access Administrator' on the subscription: $SubscriptionId which is required to assign alert reading permission to the connectors app. Please reach out to someone in your organization who can assign one of these roles to you. Once you have them, run this script again."
       exit 1
   }
 }
@@ -305,7 +305,7 @@ function CheckRoleAssignmentForDeployment {
   )
 
   if (-not (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "Contributor")) {
-      Write-Host "You are not a 'Contributor' on the subscription: $SubscriptionId which is required to create the connector on your subscription. Please get the role assigned to proceed."
+      Write-Host "You are not a 'Contributor' on the subscription: $SubscriptionId which is required to create the connector on your subscription. Please reach out to someone in your organization who can assign one of these roles to you. Once you have them, run this script again."
       exit 1
   }
 }

--- a/Onboarding/Connector/Scripts/CreateImpactReportingConnector.ps1
+++ b/Onboarding/Connector/Scripts/CreateImpactReportingConnector.ps1
@@ -46,11 +46,17 @@ function CreateCustomRoleJson {
 
 function Log {
   param (
-      [string]$Message
+      [string]$Message,
+      [string]$ForegroundColor
   )
 
   $date = Get-Date
-  Write-Host "$date - $Message" 2>&1
+  if (-not $ForegroundColor) {
+    Write-Host "$date - $Message" 2>&1
+  }
+  else {
+    Write-Host "$date - $Message" -ForegroundColor $ForegroundColor 2>&1
+  }
 }
 
 function LoginAzWithPrompt {
@@ -149,33 +155,32 @@ function Add-PermissionsForAlertReading {
   )
 
   Log "Setting up permissions for alert reading"
-  $RoleName = "Azure-Alerts-Reader-Role"
   $ConnectorAppName = "AzureImpactReportingConnector"
 
-  $RoleId = (Get-AzRoleDefinition -Name $RoleName).id
+  $RoleId = (Get-AzRoleDefinition -Name $ALERTS_READER_ROLE_NAME).id
   if (-not $RoleId) {
       Log "Creating custom role for alert reading."
       $CustomRoleJsonFilePath = "/tmp/azure-alerts-reader-role-definition.json"
-      CreateCustomRoleJson $SubscriptionId $RoleName | Out-File $CustomRoleJsonFilePath
+      CreateCustomRoleJson $SubscriptionId $ALERTS_READER_ROLE_NAME | Out-File $CustomRoleJsonFilePath
       $RoleId = (New-AzRoleDefinition -InputFile $CustomRoleJsonFilePath).id
-      Log "Custom role: $RoleName for alert reading created successfully with role id: $RoleId."
+      Log "Custom role: $ALERTS_READER_ROLE_NAME for alert reading created successfully with role id: $RoleId."
       Remove-Item -Path $CustomRoleJsonFilePath
   }
   else {
-      Log "Custom role: $RoleName for alert reading already exists with role id: $RoleId."
+      Log "Custom role: $ALERTS_READER_ROLE_NAME for alert reading already exists with role id: $RoleId."
   }
 
-  Log "Assigning the custom role: $RoleName to the reporting app: $ConnectorAppName"
+  Log "Assigning the custom role: $ALERTS_READER_ROLE_NAME to the reporting app: $ConnectorAppName"
   $ConnectorPrincipalId = (Get-AzADServicePrincipal -DisplayName $ConnectorAppName).id
 
   $AssignedCustomRole = Get-AzRoleAssignment -ObjectId $ConnectorPrincipalId -RoleDefinitionId $RoleId -Scope "/subscriptions/$SubscriptionId"
 
   if (-not $AssignedCustomRole) {
       New-AzRoleAssignment -ObjectId $ConnectorPrincipalId -RoleDefinitionId $RoleId -Scope "/subscriptions/$SubscriptionId"
-      Log "Custom role: $RoleName assigned to the reporting app: $ConnectorAppName"
+      Log "Custom role: $ALERTS_READER_ROLE_NAME assigned to the reporting app: $ConnectorAppName"
   }
   else {
-      Log "Custom role: $RoleName already assigned to the reporting app: $ConnectorAppName"
+      Log "Custom role: $ALERTS_READER_ROLE_NAME already assigned to the reporting app: $ConnectorAppName"
   }
 
   Log "Successfully setup permissions for alert reading"
@@ -203,18 +208,30 @@ function CreateConnector {
   $ProvisioningState=""
   do
   {
-      $ResponseBody = (Invoke-AzRestMethod -Method Put -Path $Path -Payload $request_body).Content | ConvertFrom-Json
+      $Response = (Invoke-AzRestMethod -Method Put -Path $Path -Payload $request_body)
+      $ResponseContent = $Response.Content
+      $StatusCode = $Response.StatusCode
+      if ( $StatusCode -eq 409 ) {
+          Log "A connector is already deployed in this subscription. A new connector will not be deployed." -ForegroundColor yellow
+          break;
+      }
+      $ResponseBody = $ResponseContent | ConvertFrom-Json
       $ProvisioningState = $ResponseBody.properties.provisioningState 
-      if ($ProvisioningState -ne "Succeeded")
+      if ($StatusCode -eq 404 -and $ResponseBody.error.code -eq "InvalidResourceType" )
       {
         $SleepDuration = $SleepDuration * 2
         Log "Attempt #${AttemptCount}: Connector creation is in progress. Waiting for $SleepDuration seconds before retrying."
         Start-Sleep -Seconds $SleepDuration
         $AttemptCount = $AttemptCount + 1
       }
-      else
+      elseif($ProvisioningState -eq "Succeeded")
       {
         Log "Attempt #${AttemptCount}: Creation of connector: $ConnectorName is successful."
+      }
+      else
+      {
+        Write-Host "Connector creation failed with status code: $StatusCode and response body: $ResponseContent" -ForegroundColor red
+        exit 1;
       }
       
   } while ($ProvisioningState -ne "Succeeded")
@@ -252,13 +269,70 @@ function Test-Input {
   Log "==== All required inputs are present ===="
 }
 
+function HasRoleAssignment {
+  param (
+      [string]$RoleName,
+      [string]$SubscriptionId
+  )
+
+  $RoleDefinitionName = (Get-AzRoleAssignment -ObjectId $AzureAdId -RoleDefinitionName $RoleName -Scope /subscriptions/$SubscriptionId).RoleDefinitionName
+  return $RoleName -eq $RoleDefinitionName
+}
+
+function CheckRoleAssignmentForSettingUpPermissions {
+  param (
+      [string]$SubscriptionId
+  )
+
+  $RoleId = (Get-AzRoleDefinition -Name $ALERTS_READER_ROLE_NAME).id
+  if (-not $roleId) {
+      Write-Host "Custom role: $ALERTS_READER_ROLE_NAME for alerts reading does not exist. Checking for built-in role: User Access Administrator role assignment as that is required for custom role creation"
+      if (-not (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "User Access Administrator")) {
+          Write-Host "You are not a 'User Access Administrator' on the subscription: $SubscriptionId. Please get the role assigned to proceed"
+          exit 1
+      }
+  }
+
+  if (-not (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "Role Based Access Administrator") -and -not (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "User Access Administrator")) {
+      Write-Host "You are neither a 'Role Based Access Administrator' nor a 'User Access Administrator' on the subscription: $SubscriptionId which is required to assign alert reading permission to the connectors app. Please get the role assigned to proceed"
+      exit 1
+  }
+}
+
+function CheckRoleAssignmentForDeployment {
+  param (
+      [string]$SubscriptionId
+  )
+
+  if (-not (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "Contributor")) {
+      Write-Host "You are not a 'Contributor' on the subscription: $SubscriptionId which is required to create the connector on your subscription. Please get the role assigned to proceed."
+      exit 1
+  }
+}
+
+function VerifyPermissions {
+  param (
+      [string]$SubscriptionId
+  )
+
+  Write-Host "Verifying permissions for the subscription: $SubscriptionId"
+
+  if (HasRoleAssignment -SubscriptionId $SubscriptionId -RoleName "Owner") {
+      Write-Host "Permissions are already set for the subscription: $SubscriptionId"
+  } else {
+      CheckRoleAssignmentForSettingUpPermissions -SubscriptionId $SubscriptionId
+      CheckRoleAssignmentForDeployment -SubscriptionId $SubscriptionId 
+  }
+}
+
 function CreateImpactReportingConnectors {
   param (
       [array]$SubscriptionIds
   )
-  # Loop through the array
+
   foreach ($CurrentSubscriptionId in $SubscriptionIds) {
       LoginAzWithPrompt $CurrentSubscriptionId
+      VerifyPermissions $CurrentSubscriptionId
       Register-Feature "Microsoft.Impact" "AzureImpactReportingConnector"
       Register-Feature "Microsoft.Impact" "AllowImpactReporting"
       Add-PermissionsForAlertReading $CurrentSubscriptionId
@@ -283,6 +357,9 @@ else {
   # Create an array with a single element
   $SubscriptionIds = @($SubscriptionId)
 }
+
+$ALERTS_READER_ROLE_NAME = "Azure-Alerts-Reader-Role"
+$AzureAdId = (Get-AzADUser -SignedIn).Id
 
 Log "==== Creating impact reporting connector(s) ===="
 CreateImpactReportingConnectors -SubscriptionIds $SubscriptionIds

--- a/Onboarding/Connector/Scripts/create-impact-reporting-connector.sh
+++ b/Onboarding/Connector/Scripts/create-impact-reporting-connector.sh
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/bin/bash
 
 # Running in debug mode
 # Uncomment to enable debug mode. Make sure you also uncomment set +x in the end of the script.
@@ -6,6 +6,8 @@
 
 # set -x
 set -e
+
+ALERTS_READER_ROLE_NAME="Azure-Alerts-Reader-Role"
 
 print_help () 
 {
@@ -135,33 +137,32 @@ setup_permissions_for_alerts_reading()
 {
   subscription_id=$1
   log "Setting up permissions for alerts reading" 
-  role_name="Azure-Alerts-Reader-Role"
   connector_app_name="AzureImpactReportingConnector"
 
-  role_id=$(az role definition list -n "$role_name"  --query [].id -o tsv)
+  role_id=$(az role definition list -n "$ALERTS_READER_ROLE_NAME"  --query [].id -o tsv)
   if [ ! "$role_id" ]; then
     log "Creating custom role for alerts reading."
     
     custom_role_json_file="/tmp/custom-role.json"
-    create_custom_role_json_file "$subscription_id" "$role_name" "$custom_role_json_file"
+    create_custom_role_json_file "$subscription_id" "$ALERTS_READER_ROLE_NAME" "$custom_role_json_file"
     role_id=$(az role definition create --role-definition "$custom_role_json_file" | jq -r ".id")
     rm -rf "$custom_role_json_file"
     
-    log "Custom role: $role_name for alerts reading created successfully with role id: $role_id."
+    log "Custom role: $ALERTS_READER_ROLE_NAME for alerts reading created successfully with role id: $role_id."
   else
-    log "Custom role: $role_name for alerts reading already exists with role id: $role_id."
+    log "Custom role: $ALERTS_READER_ROLE_NAME for alerts reading already exists with role id: $role_id."
   fi
   
-  log "Assigning the custom role: $role_name to the connector app: $connector_app_name"
+  log "Assigning the custom role: $ALERTS_READER_ROLE_NAME to the connector app: $connector_app_name"
   connector_principal_id=$(az ad sp list --display-name "$connector_app_name" --query "[].id" -o tsv)
 
   assigned_custom_role=$(az role assignment list --assignee "$connector_principal_id" --role "$role_id" --query [].id -o tsv)
 
   if [ ! "$assigned_custom_role" ]; then
     az role assignment create --role "$role_id" --assignee-object-id "$connector_principal_id" --scope "/subscriptions/$subscription_id"
-    log "Custom role: $role_name assigned to the connector app: $connector_app_name"
+    log "Custom role: $ALERTS_READER_ROLE_NAME assigned to the connector app: $connector_app_name"
   else
-    log "Custom role: $role_name already assigned to the connector app: $connector_app_name"
+    log "Custom role: $ALERTS_READER_ROLE_NAME already assigned to the connector app: $connector_app_name"
   fi
 
   log "Successfully setup permissions for alerts reading" 
@@ -183,14 +184,26 @@ create_connector()
   attempt_count=1
   sleep_duration=10
 
-  while ! az rest --method put --url "$url" --body "$request_body" --query "properties.provisioningState" | grep -q "Succeeded"; do
-    sleep_duration=$((sleep_duration*2))
-    log "Attempt #$attempt_count: Connector creation is in progress. Waiting for $sleep_duration seconds before retrying."
-    sleep "$sleep_duration"
-    attempt_count=$((attempt_count+1))
+  while true; do
+    output=$(az rest --method put --url "$url" --body "$request_body" 2>&1 || true)
+    if echo "$output" | grep "Conflict"; then
+      YELLOW='\033[0;33m'
+      echo -e "${YELLOW}A connector is already deployed in this subscription. A new connector will not be deployed."
+      tput sgr0
+      break;
+    elif echo "$output" | grep "InvalidResourceType"; then
+      sleep_duration=$((sleep_duration*2))
+      log "Attempt #$attempt_count: Connector creation is in progress. Waiting for $sleep_duration seconds before retrying."
+      sleep "$sleep_duration"
+      attempt_count=$((attempt_count+1))
+    elif echo "$output" | jq -r .properties.provisioningState | grep -q "Succeeded"; then
+      log "Creation of connector: $connector_name is complete" 
+      break;
+    else
+      log "Failed to create connector: $connector_name due to: $output" 
+    fi
   done 
 
-  log "Creation of connector: $connector_name is complete" 
 }
 
 validate_input()
@@ -210,6 +223,64 @@ validate_input()
   log "==== All required inputs are present ===="
 }
 
+has_role_assignment()
+{
+  user_principal_name=$1
+  role_name=$2
+
+  role_definition_name=$(az role assignment list --assignee "$user_principal_name" --query "[?roleDefinitionName=='$role_name' ]" --include-groups --include-inherited --include-classic-administrators | jq -r .[0].roleDefinitionName)
+  if [ "$role_definition_name" == "$role_name" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+check_role_assignment_for_setting_up_permissions()
+{
+  subscription_id=$1
+  user_principal_name=$2
+
+  role_id=$(az role definition list -n "$ALERTS_READER_ROLE_NAME"  --query [].id -o tsv)
+  if [ ! "$role_id" ]; then
+    log "Custom role: $ALERTS_READER_ROLE_NAME for alerts reading does not exist. Checking for built-in role: User Access Administrator role assignment as that is required for custom role creation"
+    if ! has_role_assignment "$user_principal_name" "User Access Administrator" ; then
+      log "You are not a 'User Access Administrator' on the subscription: $subscription_id. Please get the role assigned to proceed"
+      exit 1
+    fi
+  fi
+
+  if ! has_role_assignment "$user_principal_name" "Role Based Access Administrator" && ! has_role_assignment "$user_principal_name" "User Access Administrator" ; then
+    log "You are neither a 'Role Based Access Administrator' nor a 'User Access Administrator' on the subscription: $subscription_id which is required to assign alert reading permission to the connectors app. Please get the role assigned to proceed"
+    exit 1
+  fi
+}
+
+check_role_assignment_for_deployment()
+{
+  subscription_id=$1
+  user_principal_name=$2
+
+  if ! has_role_assignment "$user_principal_name" "Contributor"; then
+      log "You are not a 'Contributor' on the subscription: $subscription_id which is required to create the connector on your subscription. Please get the role assigned to proceed."
+      exit 1
+    fi   
+}
+
+verify_permissions()
+{
+  subscription_id=$1
+  user_principal_name=$2
+  log "Verifying permissions for the subscription: $subscription_id"
+
+  if has_role_assignment "$user_principal_name" "Owner" ; then
+    log "Permissions are already set for the subscription: $subscription_id"
+  else
+    check_role_assignment_for_setting_up_permissions "$subscription_id" "$user_principal_name" 
+    check_role_assignment_for_deployment "$subscription_id" "$user_principal_name" 
+  fi
+}
+
 create_impact_reporting_connectors()
 {
   log "==== Creating impact reporting connector(s) ===="
@@ -222,12 +293,15 @@ create_impact_reporting_connectors()
       # Create an array with a single element
       subscription_ids=("$subscription_id")
   fi
+  
+  signed_in_user=$(az ad signed-in-user show)
+  user_principal_name=$(echo "$signed_in_user" | jq -r .userPrincipalName)
 
-  # Print the array
   for current_subscription_id in "${subscription_ids[@]}"; do
       az_login_with_prompt "$current_subscription_id"
-      register_feature "Microsoft.Impact" "AzureImpactReportingConnector"
-      register_feature "Microsoft.Impact" "AllowImpactReporting"
+      # verify_permissions "$current_subscription_id" "$user_principal_name"
+      # register_feature "Microsoft.Impact" "AzureImpactReportingConnector"
+      # register_feature "Microsoft.Impact" "AllowImpactReporting"
       setup_permissions_for_alerts_reading "$current_subscription_id"
       create_connector "$current_subscription_id"
       log "==== Impact reporting connector is successfully created on your subscription: $current_subscription_id!! ===="

--- a/Onboarding/Connector/Scripts/create-impact-reporting-connector.sh
+++ b/Onboarding/Connector/Scripts/create-impact-reporting-connector.sh
@@ -299,9 +299,9 @@ create_impact_reporting_connectors()
 
   for current_subscription_id in "${subscription_ids[@]}"; do
       az_login_with_prompt "$current_subscription_id"
-      # verify_permissions "$current_subscription_id" "$user_principal_name"
-      # register_feature "Microsoft.Impact" "AzureImpactReportingConnector"
-      # register_feature "Microsoft.Impact" "AllowImpactReporting"
+      verify_permissions "$current_subscription_id" "$user_principal_name"
+      register_feature "Microsoft.Impact" "AzureImpactReportingConnector"
+      register_feature "Microsoft.Impact" "AllowImpactReporting"
       setup_permissions_for_alerts_reading "$current_subscription_id"
       create_connector "$current_subscription_id"
       log "==== Impact reporting connector is successfully created on your subscription: $current_subscription_id!! ===="

--- a/Onboarding/Connector/Scripts/create-impact-reporting-connector.sh
+++ b/Onboarding/Connector/Scripts/create-impact-reporting-connector.sh
@@ -141,7 +141,7 @@ setup_permissions_for_alerts_reading()
 
   role_id=$(az role definition list -n "$ALERTS_READER_ROLE_NAME"  --query [].id -o tsv)
   if [ ! "$role_id" ]; then
-    log "Creating custom role for alerts reading."
+    log "Creating custom role: '$ALERTS_READER_ROLE_NAME' for the Impact Reporting Connector resource to read alerts in this subscription"
     
     custom_role_json_file="/tmp/custom-role.json"
     create_custom_role_json_file "$subscription_id" "$ALERTS_READER_ROLE_NAME" "$custom_role_json_file"
@@ -188,7 +188,7 @@ create_connector()
     output=$(az rest --method put --url "$url" --body "$request_body" 2>&1 || true)
     if echo "$output" | grep "Conflict"; then
       YELLOW='\033[0;33m'
-      echo -e "${YELLOW}A connector is already deployed in this subscription. A new connector will not be deployed."
+      echo -e "${YELLOW}An Azure Monitor connector already exists in this subscription. A new connector creation is not required."
       tput sgr0
       break;
     elif echo "$output" | grep "InvalidResourceType"; then
@@ -245,13 +245,13 @@ check_role_assignment_for_setting_up_permissions()
   if [ ! "$role_id" ]; then
     log "Custom role: $ALERTS_READER_ROLE_NAME for alerts reading does not exist. Checking for built-in role: User Access Administrator role assignment as that is required for custom role creation"
     if ! has_role_assignment "$user_principal_name" "User Access Administrator" ; then
-      log "You are not a 'User Access Administrator' on the subscription: $subscription_id. Please get the role assigned to proceed"
+      log "You are not a 'User Access Administrator' on the subscription: $subscription_id. Please reach out to someone in your organization who can assign one of these roles to you. Once you have them, run this script again."
       exit 1
     fi
   fi
 
   if ! has_role_assignment "$user_principal_name" "Role Based Access Administrator" && ! has_role_assignment "$user_principal_name" "User Access Administrator" ; then
-    log "You are neither a 'Role Based Access Administrator' nor a 'User Access Administrator' on the subscription: $subscription_id which is required to assign alert reading permission to the connectors app. Please get the role assigned to proceed"
+    log "You are neither a 'Role Based Access Administrator' nor a 'User Access Administrator' on the subscription: $subscription_id which is required to assign alert reading permission to the connectors app. Please reach out to someone in your organization who can assign one of these roles to you. Once you have them, run this script again."
     exit 1
   fi
 }
@@ -262,7 +262,7 @@ check_role_assignment_for_deployment()
   user_principal_name=$2
 
   if ! has_role_assignment "$user_principal_name" "Contributor"; then
-      log "You are not a 'Contributor' on the subscription: $subscription_id which is required to create the connector on your subscription. Please get the role assigned to proceed."
+      log "You are not a 'Contributor' on the subscription: $subscription_id which is required to create the connector on your subscription. Please reach out to someone in your organization who can assign one of these roles to you. Once you have them, run this script again.."
       exit 1
     fi   
 }


### PR DESCRIPTION
Logs for role assignment verification

**Shell Script**
**Owner**
Wed Jul 10 02:27:22 PM UTC 2024 - Verifying permissions for the subscription: 3ea59b6b-245a-4111-8775-a9c1637fc499
Wed Jul 10 02:27:25 PM UTC 2024 - Permissions are already set for the subscription: 3ea59b6b-245a-4111-8775-a9c1637fc499

**Non-Owner**

_The role isnt created, and user doesnt has UAA_
Wed Jul 10 02:27:59 PM UTC 2024 - Verifying permissions for the subscription: 3b861ce0-dd31-4dff-8de6-79240859c730
Wed Jul 10 02:28:05 PM UTC 2024 - Custom role: Azure-Alerts-Reader-Role for alerts reading does not exist. Checking for built-in role: User Access Administrator role assignment as that is required for custom role creation
Wed Jul 10 02:28:08 PM UTC 2024 - You are not a 'User Access Administrator' on the subscription: 3b861ce0-dd31-4dff-8de6-79240859c730. Please get the role assigned to proceed

_Role is created, and user doesnt has UAA or RBAC_
Wed Jul 10 02:29:06 PM UTC 2024 - Verifying permissions for the subscription: 4c4cdac1-cf03-4440-ad17-12052cbdc66d
Wed Jul 10 02:29:18 PM UTC 2024 - You are neither a 'Role Based Access Administrator' nor a 'User Access Administrator' on the subscription: 4c4cdac1-cf03-4440-ad17-12052cbdc66d which is required to assign alert reading permission to the connectors app. Please get the role assigned to proceed

**Powershell Script**
**Owner**
07/09/2024 14:33:47 - Setting Azure subscription as 3ea59b6b-245a-4111-8775-a9c1637fc499

Verifying permissions for the subscription: 3ea59b6b-245a-4111-8775-a9c1637fc499
Permissions are already set for the subscription: 3ea59b6b-245a-4111-8775-a9c1637fc499


**Non-Owner**
_The role isnt created, and user doesnt has UAA_
Verifying permissions for the subscription: 3b861ce0-dd31-4dff-8de6-79240859c730
WARNING: No role definitions were found with those conditions.
WARNING: If the role was created recently keep in mind there's a slight delay between creation and public view.
WARNING: Please try again later.
Custom role: Azure-Alerts-Reader-Role for alerts reading does not exist. Checking for built-in role: User Access Administrator role assignment as that is required for custom role creation
You are not a 'User Access Administrator' on the subscription: 3b861ce0-dd31-4dff-8de6-79240859c730. Please get the role assigned to proceed

_Role is created, and user doesnt has UAA or RBAC_
Verifying permissions for the subscription: 4c4cdac1-cf03-4440-ad17-12052cbdc66d
You are neither a 'Role Based Access Administrator' nor a 'User Access Administrator' on the subscription: 4c4cdac1-cf03-4440-ad17-12052cbdc66d which is required to assign alert reading permission to the connectors app. Please get the role assigned to proceed

**Logs for Status Check**
**Bash Script**
_Conflict_
Thu Jul 11 05:33:21 AM UTC 2024 - Creating connector: AzureMonitorConnector for impact reporting
parse error: Invalid numeric literal at line 1, column 6
Thu Jul 11 05:33:30 AM UTC 2024 - Failed to create connector: AzureMonitorConnector due to: ERROR: Not Found({"error":{"code":"CONNECTORS_NOT_FOUND","message":"error finding connectors"}})
ERROR: Conflict({"error":{"code":"CONNECTOR_TYPE_CONFLICT","message":"There exists a connector resource in subscription 67d58371-52e9-4ad7-bc35-216899dac9ec with type AzureMonitor, another resource of the same type cannot be created."}})
A connector is already deployed in this subscription. A new connector will not be deployed.
Thu Jul 11 05:33:38 AM UTC 2024 - ==== Impact reporting connector is successfully created on your subscription: 67d58371-52e9-4ad7-bc35-216899dac9ec!! ====
Thu Jul 11 05:33:38 AM UTC 2024 - ==== Impact reporting connector is successfully created on your subscription(s), please head on the onboarding guide: https://aka.ms/impactRP/AzMonConnectorDocs for next step(s) ====

**Powershell**
_Conflict_
07/11/2024 05:38:13 - Successfully setup permissions for alert reading
07/11/2024 05:38:13 - Creating connector: AzureMonitorConnector for impact reporting
07/11/2024 05:38:19 - A connector is already deployed in this subscription. A new connector will not be deployed.
07/11/2024 05:38:19 - ==== Impact reporting connector is successfully created on your subscription: 67d58371-52e9-4ad7-bc35-216899dac9ec!! ====
07/11/2024 05:38:19 - ==== Impact reporting connector is successfully created on your subscription(s), please head on the onboarding guide: https://aka.ms/impactRP/AzMonConnectorDocs for next step(s) ====


